### PR TITLE
Fix compilation on 2.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ ThisBuild / githubWorkflowEnv ++= List(
 }.toMap
 
 val commonSettings = Seq(
-  scalacOptions -= "-Xfatal-warnings"
+  scalacOptions --= Seq("-Xfatal-warnings", "-source", "future")
 )
 
 val plugin = project.settings(

--- a/plugin/src/main/scala-2/BetterToStringPlugin.scala
+++ b/plugin/src/main/scala-2/BetterToStringPlugin.scala
@@ -18,7 +18,7 @@ final class BetterToStringPlugin(override val global: Global) extends Plugin {
 }
 
 final class BetterToStringPluginComponent(val global: Global) extends PluginComponent with TypingTransformers {
-  import global.*
+  import global._
   override val phaseName: String = "better-tostring-phase"
   override val runsAfter: List[String] = List("parser")
 

--- a/plugin/src/main/scala-2/Scala2CompilerApi.scala
+++ b/plugin/src/main/scala-2/Scala2CompilerApi.scala
@@ -5,7 +5,7 @@ import scala.tools.nsc.Global
 
 trait Scala2CompilerApi[G <: Global] extends CompilerApi {
   val theGlobal: G
-  import theGlobal.*
+  import theGlobal._
   type Tree = theGlobal.Tree
   type Clazz = ClassDef
   type Param = ValDef
@@ -19,7 +19,7 @@ object Scala2CompilerApi {
   def instance(global: Global): Scala2CompilerApi[global.type] =
     new Scala2CompilerApi[global.type] {
       val theGlobal: global.type = global
-      import global.*
+      import global._
 
       def params(clazz: Clazz): List[Param] = clazz.impl.body.collect {
         case v: ValDef if v.mods.hasFlag(Flags.CASEACCESSOR) => v

--- a/plugin/src/main/scala/BetterToStringImpl.scala
+++ b/plugin/src/main/scala/BetterToStringImpl.scala
@@ -45,7 +45,7 @@ object BetterToStringImpl {
     new BetterToStringImpl[api.type] {
       val compilerApi: api.type = api
 
-      import api.*
+      import api._
 
       def transformClass(
         clazz: Clazz,


### PR DESCRIPTION
After #44, all wildcard imports were replaced with * - obviously this isn't going to work in Scala 2.

Because we upgraded sbt-tpolecat and it adds the `-source future` flags under 3.x, the cross-compiled code using wildcard imports with underscore syntax `_` wouldn't work in 3.x, so I'm removing that flag (effectively restoring the behavior from before the upgrade).
