### PR TITLE
Fix #56

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,6 @@
 version = "3.0.0-RC5"
 runner.dialect = scala3
+rewrite.scala3.insertEndMarkerMinLines = 50
 maxColumn = 140
 align.preset = some
 align.tokens.add = [

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.0.0-RC5"
+version = "3.0.0-RC6"
 runner.dialect = scala3
 rewrite.scala3.insertEndMarkerMinLines = 50
 maxColumn = 140

--- a/build.sbt
+++ b/build.sbt
@@ -97,8 +97,10 @@ val tests = project.settings(
       case "3.0.0-RC2" => "0.7.25"
       case _           => "0.7.26"
     }) % Test
-  )
-)
+  ),
+  buildInfoKeys ++= Seq(scalaVersion),
+  buildInfoPackage := "b2s.buildinfo"
+).enablePlugins(BuildInfoPlugin)
 
 val betterToString =
   project

--- a/plugin/src/main/scala-2/BetterToStringPlugin.scala
+++ b/plugin/src/main/scala-2/BetterToStringPlugin.scala
@@ -28,6 +28,9 @@ final class BetterToStringPluginComponent(val global: Global) extends PluginComp
   private def modifyClasses(tree: Tree, enclosingObject: Option[ModuleDef]): Tree =
     tree match {
       case p: PackageDef   => p.copy(stats = p.stats.map(modifyClasses(_, None)))
+      // https://github.com/polyvariant/better-tostring/issues/59
+      // start here - ModuleDef which is a case object should be transformed.
+      // We might need to change the type of CompilerApi#Clazz to allow objects.
       case m: ModuleDef    =>
         m.copy(impl = m.impl.copy(body = m.impl.body.map(modifyClasses(_, Some(m)))))
       case clazz: ClassDef =>

--- a/plugin/src/main/scala-2/Scala2CompilerApi.scala
+++ b/plugin/src/main/scala-2/Scala2CompilerApi.scala
@@ -55,6 +55,7 @@ object Scala2CompilerApi {
       }
 
       def isCaseClass(clazz: Clazz): Boolean = clazz.mods.hasFlag(Flags.CASE)
+      def isEnum(clazz: Clazz): Boolean = false //enums don't exist in Scala 2
       def isObject(clazz: Clazz): Boolean = clazz.mods.hasFlag(Flags.MODULE)
     }
 

--- a/plugin/src/main/scala-2/Scala2CompilerApi.scala
+++ b/plugin/src/main/scala-2/Scala2CompilerApi.scala
@@ -55,7 +55,6 @@ object Scala2CompilerApi {
       }
 
       def isCaseClass(clazz: Clazz): Boolean = clazz.mods.hasFlag(Flags.CASE)
-      def isEnum(clazz: Clazz): Boolean = false //enums don't exist in Scala 2
       def isObject(clazz: Clazz): Boolean = clazz.mods.hasFlag(Flags.MODULE)
     }
 

--- a/plugin/src/main/scala-2/Scala2CompilerApi.scala
+++ b/plugin/src/main/scala-2/Scala2CompilerApi.scala
@@ -49,11 +49,13 @@ object Scala2CompilerApi {
       def addMethod(clazz: Clazz, method: Method): Clazz =
         clazz.copy(impl = clazz.impl.copy(body = clazz.impl.body :+ method))
 
-      def methodNames(clazz: Clazz): List[String] = clazz.impl.body.collect { case d: DefDef =>
-        d.name.toString
+      def methodNames(clazz: Clazz): List[String] = clazz.impl.body.collect {
+        case d: DefDef => d.name.toString
+        case d: ValDef => d.name.toString
       }
 
       def isCaseClass(clazz: Clazz): Boolean = clazz.mods.hasFlag(Flags.CASE)
+      def isObject(clazz: Clazz): Boolean = clazz.mods.hasFlag(Flags.MODULE)
     }
 
 }

--- a/plugin/src/main/scala-3/BetterToStringPlugin.scala
+++ b/plugin/src/main/scala-3/BetterToStringPlugin.scala
@@ -8,9 +8,10 @@ import dotty.tools.dotc.core.Symbols
 import dotty.tools.dotc.plugins.PluginPhase
 import dotty.tools.dotc.plugins.StandardPlugin
 import dotty.tools.dotc.typer.FrontEnd
-import tpd.*
 
 import scala.annotation.tailrec
+
+import tpd.*
 
 final class BetterToStringPlugin extends StandardPlugin:
   override val name: String = "better-tostring"

--- a/plugin/src/main/scala-3/Scala3CompilerApi.scala
+++ b/plugin/src/main/scala-3/Scala3CompilerApi.scala
@@ -35,7 +35,8 @@ object Scala3CompilerApi:
         case v: ValDef if v.mods.is(CaseAccessor) => v
       }
 
-    def className(clazz: Clazz): String = clazz.clazz.name.toString
+    def className(clazz: Clazz): String =
+      clazz.clazz.originalName.toString
 
     def isPackageOrPackageObject(enclosingObject: EnclosingObject): Boolean =
       enclosingObject.is(Package) || enclosingObject.isPackageObject
@@ -69,15 +70,17 @@ object Scala3CompilerApi:
     def addMethod(clazz: Clazz, method: Method): Clazz =
       clazz.mapTemplate(t => cpy.Template(t)(body = t.body :+ method))
 
-    def methodNames(clazz: Clazz): List[String] = clazz.t.body.collect { case d: DefDef =>
-      d.name.toString
-    }
+    // note: also returns vals because why not
+    def methodNames(clazz: Clazz): List[String] =
+      clazz.t.body.collect { case d: (DefDef | ValDef) =>
+        d.name.toString
+      }
 
-    def isCaseClass(clazz: Clazz): Boolean = {
+    def isCaseClass(clazz: Clazz): Boolean =
       // for some reason, this is true for case objects too
       // hence the additional check for not being a module (object)
-      clazz.clazz.flags.is(CaseClass) &&
-        !clazz.clazz.flags.is(Module)
-    }
+      clazz.clazz.flags.is(CaseClass)
+
+    def isObject(clazz: Clazz): Boolean = clazz.clazz.flags.is(Module)
 
 end Scala3CompilerApi

--- a/plugin/src/main/scala-3/Scala3CompilerApi.scala
+++ b/plugin/src/main/scala-3/Scala3CompilerApi.scala
@@ -1,19 +1,21 @@
 package com.kubukoz
 
+import dotty.tools.dotc.ast.Trees
 import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.core.Constants.Constant
 import dotty.tools.dotc.core.Contexts.Context
-import dotty.tools.dotc.core.Symbols
+import dotty.tools.dotc.core.Decorators.*
+import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Flags.CaseAccessor
 import dotty.tools.dotc.core.Flags.CaseClass
 import dotty.tools.dotc.core.Flags.Module
 import dotty.tools.dotc.core.Flags.Override
 import dotty.tools.dotc.core.Flags.Package
-import dotty.tools.dotc.core.Types
 import dotty.tools.dotc.core.Names
-import dotty.tools.dotc.core.Constants.Constant
+import dotty.tools.dotc.core.Symbols
 import dotty.tools.dotc.core.Symbols.ClassSymbol
-import dotty.tools.dotc.core.Decorators.*
-import dotty.tools.dotc.ast.Trees
+import dotty.tools.dotc.core.Types
+
 import tpd.*
 
 trait Scala3CompilerApi extends CompilerApi:
@@ -78,9 +80,12 @@ object Scala3CompilerApi:
 
     def isCaseClass(clazz: Clazz): Boolean =
       // for some reason, this is true for case objects too
-      // hence the additional check for not being a module (object)
       clazz.clazz.flags.is(CaseClass)
 
-    def isObject(clazz: Clazz): Boolean = clazz.clazz.flags.is(Module)
+    def isEnum(clazz: Clazz): Boolean =
+      clazz.clazz.isSubClass(Symbols.requiredClass("scala.runtime.EnumValue"))
+
+    def isObject(clazz: Clazz): Boolean =
+      clazz.clazz.flags.is(Module)
 
 end Scala3CompilerApi

--- a/plugin/src/main/scala-3/Scala3CompilerApi.scala
+++ b/plugin/src/main/scala-3/Scala3CompilerApi.scala
@@ -5,6 +5,7 @@ import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Symbols
 import dotty.tools.dotc.core.Flags.CaseAccessor
 import dotty.tools.dotc.core.Flags.CaseClass
+import dotty.tools.dotc.core.Flags.Module
 import dotty.tools.dotc.core.Flags.Override
 import dotty.tools.dotc.core.Flags.Package
 import dotty.tools.dotc.core.Types
@@ -72,6 +73,11 @@ object Scala3CompilerApi:
       d.name.toString
     }
 
-    def isCaseClass(clazz: Clazz): Boolean = clazz.clazz.flags.is(CaseClass)
+    def isCaseClass(clazz: Clazz): Boolean = {
+      // for some reason, this is true for case objects too
+      // hence the additional check for not being a module (object)
+      clazz.clazz.flags.is(CaseClass) &&
+        !clazz.clazz.flags.is(Module)
+    }
 
 end Scala3CompilerApi

--- a/plugin/src/main/scala-3/Scala3CompilerApi.scala
+++ b/plugin/src/main/scala-3/Scala3CompilerApi.scala
@@ -82,9 +82,6 @@ object Scala3CompilerApi:
       // for some reason, this is true for case objects too
       clazz.clazz.flags.is(CaseClass)
 
-    def isEnum(clazz: Clazz): Boolean =
-      clazz.clazz.isSubClass(Symbols.requiredClass("scala.runtime.EnumValue"))
-
     def isObject(clazz: Clazz): Boolean =
       clazz.clazz.flags.is(Module)
 

--- a/plugin/src/main/scala/BetterToStringImpl.scala
+++ b/plugin/src/main/scala/BetterToStringImpl.scala
@@ -24,6 +24,7 @@ trait CompilerApi {
   def addMethod(clazz: Clazz, method: Method): Clazz
   def methodNames(clazz: Clazz): List[String]
   def isCaseClass(clazz: Clazz): Boolean
+  def isEnum(clazz: Clazz): Boolean
   def isObject(clazz: Clazz): Boolean
 }
 
@@ -55,8 +56,7 @@ object BetterToStringImpl {
       ): Clazz = {
         val hasToString: Boolean = methodNames(clazz).contains("toString")
 
-        val shouldModify =
-          isCaseClass(clazz) && !isNested && !hasToString
+        val shouldModify = (isCaseClass(clazz) && !isNested) && !hasToString
 
         if (shouldModify) overrideToString(clazz, enclosingObject)
         else clazz
@@ -83,13 +83,13 @@ object BetterToStringImpl {
         }
 
         val paramParts =
-          if (api.isCaseClass(clazz) && !api.isObject(clazz))
+          if (api.isObject(clazz)) Nil
+          else
             List(
               List(literalConstant("(")),
               paramListParts,
               List(literalConstant(")"))
             ).flatten
-          else Nil
 
         val parts =
           namePart :: paramParts

--- a/plugin/src/main/scala/BetterToStringImpl.scala
+++ b/plugin/src/main/scala/BetterToStringImpl.scala
@@ -24,7 +24,6 @@ trait CompilerApi {
   def addMethod(clazz: Clazz, method: Method): Clazz
   def methodNames(clazz: Clazz): List[String]
   def isCaseClass(clazz: Clazz): Boolean
-  def isEnum(clazz: Clazz): Boolean
   def isObject(clazz: Clazz): Boolean
 }
 

--- a/plugin/src/main/scala/BetterToStringImpl.scala
+++ b/plugin/src/main/scala/BetterToStringImpl.scala
@@ -55,7 +55,7 @@ object BetterToStringImpl {
       ): Clazz = {
         val hasToString: Boolean = methodNames(clazz).contains("toString")
 
-        val shouldModify = (isCaseClass(clazz) && !isNested) && !hasToString
+        val shouldModify = isCaseClass(clazz) && !isNested && !hasToString
 
         if (shouldModify) overrideToString(clazz, enclosingObject)
         else clazz

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.20")
 addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.12.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")

--- a/tests/src/test/scala-3/Scala3Tests.scala
+++ b/tests/src/test/scala-3/Scala3Tests.scala
@@ -4,10 +4,14 @@ class Scala3Tests extends FunSuite:
   test("an enum made of constants should have a normal toString") {
     assertEquals(
       ScalaVersion.Scala2.toString,
+      // https://github.com/polyvariant/better-tostring/issues/60
+      // should be "ScalaVersion.Scala2"
       "Scala2"
     )
     assertEquals(
       ScalaVersion.Scala3.toString,
+      // https://github.com/polyvariant/better-tostring/issues/60
+      // should be "ScalaVersion.Scala3"
       "Scala3"
     )
   }
@@ -16,6 +20,12 @@ class Scala3Tests extends FunSuite:
     assertEquals(
       User.LoggedIn("admin").toString,
       "User.LoggedIn(name = admin)"
+    )
+    assertEquals(
+      User.Unauthorized.toString,
+      // https://github.com/polyvariant/better-tostring/issues/60
+      // should be "User.Unauthorized"
+      "Unauthorized"
     )
   }
 

--- a/tests/src/test/scala-3/Scala3Tests.scala
+++ b/tests/src/test/scala-3/Scala3Tests.scala
@@ -1,0 +1,30 @@
+import munit.FunSuite
+
+class Scala3Tests extends FunSuite:
+  test("an enum made of constants should have a normal toString") {
+    assertEquals(
+      ScalaVersion.Scala2.toString,
+      "ScalaVersion.Scala2"
+    )
+  }
+
+  test("an enum being an ADT should get a custom toString - with parameters") {
+    assertEquals(
+      User.LoggedIn("admin").toString,
+      "User.LoggedIn(name = admin)"
+    )
+  }
+
+  test("an enum being an ADT should get a custom toString - no parameters") {
+    assertEquals(
+      User.Unauthorized.toString,
+      "User.Unauthorized"
+    )
+  }
+
+enum ScalaVersion:
+  case Scala2, Scala3
+
+enum User:
+  case LoggedIn(name: String)
+  case Unauthorized

--- a/tests/src/test/scala-3/Scala3Tests.scala
+++ b/tests/src/test/scala-3/Scala3Tests.scala
@@ -6,24 +6,47 @@ class Scala3Tests extends FunSuite:
       ScalaVersion.Scala2.toString,
       "ScalaVersion.Scala2"
     )
+    assertEquals(
+      ScalaVersion.Scala3.toString,
+      "ScalaVersion.Scala3"
+    )
   }
 
-  test("an enum being an ADT should get a custom toString - with parameters") {
+  test("an enum being an ADT should get a custom toString") {
     assertEquals(
       User.LoggedIn("admin").toString,
       "User.LoggedIn(name = admin)"
     )
-  }
 
-  test("an enum being an ADT should get a custom toString - no parameters") {
     assertEquals(
       User.Unauthorized.toString,
       "User.Unauthorized"
     )
   }
 
+  test("an enum with a custom toString should use it") {
+    assertEquals(
+      EnumCustomTostring.SimpleCase.toString,
+      "example"
+    )
+
+    // https://github.com/polyvariant/better-tostring/issues/34
+    // we aren't there yet - need to be able to find inherited `toString`s first
+    assertEquals(
+      EnumCustomTostring.ParameterizedCase("foo").toString,
+      // Should be "example" because the existing toString should take precedence.
+      // Update the test when #34 is fixed.
+      "EnumCustomTostring.ParameterizedCase(value = foo)"
+    )
+  }
+
 enum ScalaVersion:
   case Scala2, Scala3
+
+enum EnumCustomTostring:
+  case SimpleCase
+  case ParameterizedCase(value: String)
+  override def toString: String = "example"
 
 enum User:
   case LoggedIn(name: String)

--- a/tests/src/test/scala-3/Scala3Tests.scala
+++ b/tests/src/test/scala-3/Scala3Tests.scala
@@ -4,11 +4,11 @@ class Scala3Tests extends FunSuite:
   test("an enum made of constants should have a normal toString") {
     assertEquals(
       ScalaVersion.Scala2.toString,
-      "ScalaVersion.Scala2"
+      "Scala2"
     )
     assertEquals(
       ScalaVersion.Scala3.toString,
-      "ScalaVersion.Scala3"
+      "Scala3"
     )
   }
 
@@ -16,11 +16,6 @@ class Scala3Tests extends FunSuite:
     assertEquals(
       User.LoggedIn("admin").toString,
       "User.LoggedIn(name = admin)"
-    )
-
-    assertEquals(
-      User.Unauthorized.toString,
-      "User.Unauthorized"
     )
   }
 

--- a/tests/src/test/scala/Demo.scala
+++ b/tests/src/test/scala/Demo.scala
@@ -74,6 +74,23 @@ class Tests extends FunSuite {
       "LocalClass(a)"
     )
   }
+
+  test("Lone case object should use the default toString") {
+    assertEquals(CaseObject.toString, "CaseObject")
+  }
+
+  test("Case object with toString should not get extra toString") {
+    assertEquals(
+      CaseObjectWithToString.toString,
+      "example"
+    )
+  }
+}
+
+case object CaseObject
+
+case object CaseObjectWithToString {
+  override val toString: String = "example"
 }
 
 final case class SimpleCaseClass(name: String, age: Int)

--- a/tests/src/test/scala/Tests.scala
+++ b/tests/src/test/scala/Tests.scala
@@ -1,5 +1,4 @@
 import munit.FunSuite
-import scala.runtime.ScalaRunTime
 import munit.TestOptions
 import b2s.buildinfo.BuildInfo
 
@@ -53,7 +52,8 @@ class Tests extends FunSuite {
     )
   }
 
-  test("Case object nested in an object should include enclosing object's name") {
+  // https://github.com/polyvariant/better-tostring/issues/59
+  test(onlyScala3("Case object nested in an object should include enclosing object's name")) {
     assertEquals(
       ObjectNestedParent.ObjectNestedObject.toString,
       "ObjectNestedParent.ObjectNestedObject"
@@ -102,19 +102,18 @@ class Tests extends FunSuite {
     )
   }
 
-  // https://github.com/polyvariant/better-tostring/issues/59
-  // On scala 2, this is expected to fail.
-  test {
-    val name = "Case object with toString val should not get extra toString"
-
-    val isScala3 = BuildInfo.scalaVersion.startsWith("3")
-    if (isScala3) name: TestOptions else name.fail
-  } {
+  test("Case object with toString val should not get extra toString") {
     assertEquals(
       CaseObjectWithToStringVal.toString,
       "example"
     )
   }
+
+  def onlyScala3(name: String) = {
+    val isScala3 = BuildInfo.scalaVersion.startsWith("3")
+    if (isScala3) name: TestOptions else name.fail
+  }
+
 }
 
 case object CaseObject

--- a/tests/src/test/scala/Tests.scala
+++ b/tests/src/test/scala/Tests.scala
@@ -1,4 +1,7 @@
 import munit.FunSuite
+import scala.runtime.ScalaRunTime
+import munit.TestOptions
+import b2s.buildinfo.BuildInfo
 
 class Tests extends FunSuite {
 
@@ -43,10 +46,17 @@ class Tests extends FunSuite {
     )
   }
 
-  test("Class nested in an object should include enclosing object's name") {
+  test("Case class nested in an object should include enclosing object's name") {
     assertEquals(
       ObjectNestedParent.ObjectNestedClass("Joe").toString,
       "ObjectNestedParent.ObjectNestedClass(name = Joe)"
+    )
+  }
+
+  test("Case object nested in an object should include enclosing object's name") {
+    assertEquals(
+      ObjectNestedParent.ObjectNestedObject.toString,
+      "ObjectNestedParent.ObjectNestedObject"
     )
   }
 
@@ -92,7 +102,14 @@ class Tests extends FunSuite {
     )
   }
 
-  test("Case object with toString val should not get extra toString") {
+  // https://github.com/polyvariant/better-tostring/issues/59
+  // On scala 2, this is expected to fail.
+  test {
+    val name = "Case object with toString val should not get extra toString"
+
+    val isScala3 = BuildInfo.scalaVersion.startsWith("3")
+    if (isScala3) name: TestOptions else name.fail
+  } {
     assertEquals(
       CaseObjectWithToStringVal.toString,
       "example"
@@ -105,6 +122,7 @@ case object CaseObject
 case object CaseObjectWithToString {
   override def toString: String = "example"
 }
+
 case object CaseObjectWithToStringVal {
   override val toString: String = "example"
 }
@@ -115,6 +133,7 @@ final case class MultiParameterList(name: String, age: Int)(val s: String)
 final case class CustomTostring(name: String) {
   override def toString: String = "***"
 }
+
 final case class CustomTostringVal(name: String) {
   override val toString: String = "***"
 }
@@ -129,6 +148,7 @@ final class NestedParent() {
 
 object ObjectNestedParent {
   case class ObjectNestedClass(name: String)
+  case object ObjectNestedObject
 }
 
 final class DeeplyNestedInClassGrandparent {

--- a/tests/src/test/scala/Tests.scala
+++ b/tests/src/test/scala/Tests.scala
@@ -27,6 +27,12 @@ class Tests extends FunSuite {
       "***"
     )
   }
+  test("Case class with custom toString val should not be overridden") {
+    assertEquals(
+      CustomTostringVal("Joe").toString,
+      "***"
+    )
+  }
 
   test("Method with alternate constructors should stringify based on primary constructor") {
     assertEquals(
@@ -85,11 +91,21 @@ class Tests extends FunSuite {
       "example"
     )
   }
+
+  test("Case object with toString val should not get extra toString") {
+    assertEquals(
+      CaseObjectWithToStringVal.toString,
+      "example"
+    )
+  }
 }
 
 case object CaseObject
 
 case object CaseObjectWithToString {
+  override def toString: String = "example"
+}
+case object CaseObjectWithToStringVal {
   override val toString: String = "example"
 }
 
@@ -98,6 +114,9 @@ final case class MultiParameterList(name: String, age: Int)(val s: String)
 
 final case class CustomTostring(name: String) {
   override def toString: String = "***"
+}
+final case class CustomTostringVal(name: String) {
+  override val toString: String = "***"
 }
 
 final case class HasOtherConstructors(s: String) {


### PR DESCRIPTION
- Fixes #56 by including vals in our search for existing `toString`s
- removes `$` and `()` from the toStrings of case objects in Scala 3 (I think it wasn't an issue in Scala 2 because we never touch case objects in these versions)
- Adds some tests that should help when working on #34 and #60, as well as current enum subclass behavior