### PR TITLE
Update Scala versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,16 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala:
-          - 2.12.12
           - 2.12.13
           - 2.12.14
+          - 2.12.15
           - 2.13.4
           - 2.13.5
           - 2.13.6
           - 3.0.0
           - 3.0.1
+          - 3.0.2
+          - 3.1.0-RC2
         java: [graalvm-ce-java11@20.3.0]
     runs-on: ${{ matrix.os }}
     steps:
@@ -109,16 +111,6 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (2.12.12)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-2.12.12-${{ matrix.java }}
-
-      - name: Inflate target directories (2.12.12)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
       - name: Download target directories (2.12.13)
         uses: actions/download-artifact@v2
         with:
@@ -135,6 +127,16 @@ jobs:
           name: target-${{ matrix.os }}-2.12.14-${{ matrix.java }}
 
       - name: Inflate target directories (2.12.14)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (2.12.15)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-2.12.15-${{ matrix.java }}
+
+      - name: Inflate target directories (2.12.15)
         run: |
           tar xf targets.tar
           rm targets.tar
@@ -185,6 +187,26 @@ jobs:
           name: target-${{ matrix.os }}-3.0.1-${{ matrix.java }}
 
       - name: Inflate target directories (3.0.1)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.0.2)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.0.2-${{ matrix.java }}
+
+      - name: Inflate target directories (3.0.2)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.1.0-RC2)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.1.0-RC2-${{ matrix.java }}
+
+      - name: Inflate target directories (3.1.0-RC2)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -29,16 +29,18 @@ ThisBuild / resolvers += Resolver.JCenterRepository
 
 ThisBuild / scalaVersion := "3.0.0"
 ThisBuild / crossScalaVersions := Seq(
-  "2.12.12",
   "2.12.13",
   "2.12.14",
+  "2.12.15",
   //
   "2.13.4",
   "2.13.5",
   "2.13.6",
   //
   "3.0.0",
-  "3.0.1"
+  "3.0.1",
+  "3.0.2",
+  "3.1.0-RC2",
 )
 
 ThisBuild / githubWorkflowJavaVersions := Seq(GraalVM11)


### PR DESCRIPTION
Closes #71 and #68. Also adds the current milestone 3.1.0-RC2.
