### PR TITLE
Scala 3.1.0-RC3 support, use the right phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           - 3.0.1
           - 3.0.2
           - 3.1.0-RC2
+          - 3.1.0-RC3
         java: [graalvm-ce-java11@20.3.0]
     runs-on: ${{ matrix.os }}
     steps:
@@ -207,6 +208,16 @@ jobs:
           name: target-${{ matrix.os }}-3.1.0-RC2-${{ matrix.java }}
 
       - name: Inflate target directories (3.1.0-RC2)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.1.0-RC3)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.1.0-RC3-${{ matrix.java }}
+
+      - name: Inflate target directories (3.1.0-RC3)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The plugin is currently published for the following Scala versions:
 
 - 2.12.13, 2.12.14, 2.12.15
 - 2.13.4, 2.13.5, 2.13.6
-- 3.0.0, 3.0.1, 3.0.2, 3.1.0-RC2
+- 3.0.0, 3.0.1, 3.0.2, 3.1.0-RC2, 3.1.0-RC3
 
 For older Scala versions, see [previous versions of better-tostring](https://repo1.maven.org/maven2/org/polyvariant) ([or even older versions](https://repo1.maven.org/maven2/org/polyvariant)).
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ ThisBuild / crossScalaVersions := Seq(
   "3.0.1",
   "3.0.2",
   "3.1.0-RC2",
+  "3.1.0-RC3",
 )
 
 ThisBuild / githubWorkflowJavaVersions := Seq(GraalVM11)

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ ThisBuild / crossScalaVersions := Seq(
   "3.0.1",
   "3.0.2",
   "3.1.0-RC2",
-  "3.1.0-RC3",
+  "3.1.0-RC3"
 )
 
 ThisBuild / githubWorkflowJavaVersions := Seq(GraalVM11)
@@ -83,31 +83,44 @@ val plugin = project.settings(
         s"scala3-compiler_3"
       else "scala-compiler"
     ) % scalaVersion.value
-  )
+  ),
+  Compile / unmanagedSourceDirectories ++= {
+    val extraDirectoriesWithPredicates = Map[String, String => Boolean](
+      ("scala-3.0.x", (_.startsWith("3.0"))),
+      ("scala-3.1.0+", (v => v.startsWith("3") && !v.startsWith("3.0")))
+    )
+
+    extraDirectoriesWithPredicates.collect {
+      case (dir, predicate) if predicate(scalaVersion.value) =>
+        sourceDirectory.value / "main" / dir
+    }.toList
+  }
 )
 
-val tests = project.settings(
-  (publish / skip) := true,
-  commonSettings,
-  scalacOptions ++= {
-    val jar = (plugin / Compile / packageBin).value
-    Seq(
-      s"-Xplugin:${jar.getAbsolutePath}",
-      s"-Xplugin-require:better-tostring",
-      s"-Jdummy=${jar.lastModified}"
-    ) //borrowed from bm4
-  },
-  libraryDependencies ++= Seq(
-    "org.scalameta" %% "munit" % (scalaVersion.value match {
-      case "3.0.0-M3"  => "0.7.22"
-      case "3.0.0-RC1" => "0.7.23"
-      case "3.0.0-RC2" => "0.7.25"
-      case _           => "0.7.26"
-    }) % Test
-  ),
-  buildInfoKeys ++= Seq(scalaVersion),
-  buildInfoPackage := "b2s.buildinfo"
-).enablePlugins(BuildInfoPlugin)
+val tests = project
+  .settings(
+    (publish / skip) := true,
+    commonSettings,
+    scalacOptions ++= {
+      val jar = (plugin / Compile / packageBin).value
+      Seq(
+        s"-Xplugin:${jar.getAbsolutePath}",
+        s"-Xplugin-require:better-tostring",
+        s"-Jdummy=${jar.lastModified}"
+      ) //borrowed from bm4
+    },
+    libraryDependencies ++= Seq(
+      "org.scalameta" %% "munit" % (scalaVersion.value match {
+        case "3.0.0-M3"  => "0.7.22"
+        case "3.0.0-RC1" => "0.7.23"
+        case "3.0.0-RC2" => "0.7.25"
+        case _           => "0.7.26"
+      }) % Test
+    ),
+    buildInfoKeys ++= Seq(scalaVersion),
+    buildInfoPackage := "b2s.buildinfo"
+  )
+  .enablePlugins(BuildInfoPlugin)
 
 val betterToString =
   project

--- a/build.sbt
+++ b/build.sbt
@@ -109,14 +109,7 @@ val tests = project
         s"-Jdummy=${jar.lastModified}"
       ) //borrowed from bm4
     },
-    libraryDependencies ++= Seq(
-      "org.scalameta" %% "munit" % (scalaVersion.value match {
-        case "3.0.0-M3"  => "0.7.22"
-        case "3.0.0-RC1" => "0.7.23"
-        case "3.0.0-RC2" => "0.7.25"
-        case _           => "0.7.26"
-      }) % Test
-    ),
+    libraryDependencies ++= Seq("org.scalameta" %% "munit" % "0.7.26" % Test),
     buildInfoKeys ++= Seq(scalaVersion),
     buildInfoPackage := "b2s.buildinfo"
   )

--- a/plugin/src/main/scala-3.0.x/AfterPhase.scala
+++ b/plugin/src/main/scala-3.0.x/AfterPhase.scala
@@ -1,0 +1,3 @@
+package org.polyvariant
+
+val AfterPhase = dotty.tools.dotc.typer.FrontEnd

--- a/plugin/src/main/scala-3.1.0+/AfterPhase.scala
+++ b/plugin/src/main/scala-3.1.0+/AfterPhase.scala
@@ -1,0 +1,3 @@
+package org.polyvariant
+
+val AfterPhase = dotty.tools.dotc.typer.TyperPhase

--- a/plugin/src/main/scala-3/BetterToStringPlugin.scala
+++ b/plugin/src/main/scala-3/BetterToStringPlugin.scala
@@ -7,7 +7,6 @@ import dotty.tools.dotc.core.Flags.Package
 import dotty.tools.dotc.core.Symbols
 import dotty.tools.dotc.plugins.PluginPhase
 import dotty.tools.dotc.plugins.StandardPlugin
-import dotty.tools.dotc.typer.FrontEnd
 
 import scala.annotation.tailrec
 
@@ -21,7 +20,7 @@ final class BetterToStringPlugin extends StandardPlugin:
 final class BetterToStringPluginPhase extends PluginPhase:
 
   override val phaseName: String = "better-tostring-phase"
-  override val runsAfter: Set[String] = Set(FrontEnd.name)
+  override val runsAfter: Set[String] = Set(org.polyvariant.AfterPhase.name)
 
   override def transformTemplate(t: Template)(using ctx: Context): Tree =
     val clazz = ctx.owner.asClass


### PR DESCRIPTION
- Add 3.1.0-RC3
- Support Scala 3.1.0-RC3, use version-specific phase name
