### PR TITLE
Add failing test for #34

### DIFF
--- a/plugin/src/main/scala/BetterToStringImpl.scala
+++ b/plugin/src/main/scala/BetterToStringImpl.scala
@@ -39,6 +39,7 @@ trait CompilerApi {
   def createToString(clazz: Clazz, body: Tree): Method
   def addMethod(clazz: Clazz, method: Method): Clazz
   def methodNames(clazz: Clazz): List[String]
+  // better name: "is case class or object"
   def isCaseClass(clazz: Clazz): Boolean
   def isObject(clazz: Clazz): Boolean
 }
@@ -69,6 +70,7 @@ object BetterToStringImpl {
         isNested: Boolean,
         enclosingObject: Option[EnclosingObject]
       ): Clazz = {
+        // technically, the method found by this can be even something like "def toString(s: String): Unit", but we're ignoring that
         val hasToString: Boolean = methodNames(clazz).contains("toString")
 
         val shouldModify = isCaseClass(clazz) && !isNested && !hasToString

--- a/tests/src/test/scala/Tests.scala
+++ b/tests/src/test/scala/Tests.scala
@@ -122,6 +122,21 @@ class Tests extends FunSuite {
     )
   }
 
+  // https://github.com/polyvariant/better-tostring/issues/34
+  test("(FAIL) Case class with inherited toString should not get extra toString".fail) {
+    assertEquals(
+      HasInheritedToString(0).toString,
+      "defined in superclass"
+    )
+  }
+
+  test("Case class with inherited and overridden toString should use the override") {
+    assertEquals(
+      HasInheritedAndCustomToString(0).toString,
+      "defined in child"
+    )
+  }
+
 }
 
 case object CaseObject
@@ -174,4 +189,14 @@ object MethodLocalWrapper {
     LocalClass("a").toString()
   }
 
+}
+
+trait HasToString {
+  override def toString(): String = "defined in superclass"
+}
+
+case class HasInheritedToString(i: Int) extends HasToString
+
+case class HasInheritedAndCustomToString(i: Int) extends HasToString {
+  override def toString(): String = "defined in child"
 }


### PR DESCRIPTION
In case someone ever picks it up, adding a test that's supposed to pass when #34 is resolved.

Currently marked as `.fail` so it's actually _expected_ to fail.