### PR TITLE
Unblock scheduled release check and skip superseded RCs

### DIFF
--- a/.github/workflows/check-new-scala-releases.yml
+++ b/.github/workflows/check-new-scala-releases.yml
@@ -97,9 +97,29 @@ jobs:
             exit 0
           fi
 
+          # Drop RCs whose final release is also a candidate: publishing 3.9.0-RC5 and
+          # 3.9.0-RC6 right before 3.9.0 is wasted work (one scheduled run each, and the
+          # RCs get dropped from scala-versions again once the final ships — see d4200da).
+          # An RC with no final in the set is still picked up, so pre-release support works.
+          pruned_file="$(mktemp)"
+          jq -s -c '
+            (map(select(.version | test("-RC[0-9]+$") | not) | .version)) as $finals
+            | map(select(
+                .version as $v
+                | ($finals | any(. as $f | $v | startswith($f + "-RC")))
+                | not
+              ))
+            | .[]
+          ' "$new_candidates_file" > "$pruned_file"
+
+          pruned_count="$(wc -l < "$pruned_file" | tr -d ' ')"
+          if [ "$pruned_count" -ne "$new_count" ]; then
+            echo "Skipping $((new_count - pruned_count)) RC(s) superseded by a final release in this batch."
+          fi
+
           # Sort oldest first by created_at
           sorted_file="$(mktemp)"
-          jq -s 'sort_by(.created_at) | .[]' -c "$new_candidates_file" > "$sorted_file"
+          jq -s 'sort_by(.created_at) | .[]' -c "$pruned_file" > "$sorted_file"
 
           jq -r '"  - " + .version + " (created " + .created_at + ")"' "$sorted_file"
 
@@ -164,18 +184,34 @@ jobs:
           # The issue check above is the primary guard, but it only works if the tracking
           # issue was actually created. If add-version fails before that point, no issue
           # exists and $picked would be re-dispatched on every run. Fall back to asking
-          # whether add-version already ran for this exact version and failed.
-          previous_failure="$(gh run list --workflow=add-version.yml --status=failure --limit 50 \
-            --json displayTitle,url \
-            --jq "[.[] | select(.displayTitle | contains(\"Version $picked \"))] | .[0].url // empty")"
-          if [ -n "$previous_failure" ]; then
-            echo "add-version already failed for $picked ($previous_failure) without leaving an open issue."
-            echo "Not re-dispatching; investigate that run first."
-            {
-              echo "**Skipped \`$picked\`:** a previous [add-version run]($previous_failure) failed and left no open tracking issue."
-              echo "Re-run add-version.yml manually once the cause is fixed."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+          # what the *latest* add-version run for this exact version did.
+          #
+          # Only the latest run counts, not "any run ever failed": a stale failure would
+          # otherwise block the version forever, even after the cause was fixed. Re-running
+          # add-version successfully (or manually) clears the block on its own.
+          latest_run="$(gh run list --workflow=add-version.yml --limit 100 \
+            --json displayTitle,url,conclusion,status \
+            --jq "[.[] | select(.displayTitle | startswith(\"Add Scala Version $picked (\"))] | .[0] // empty")"
+
+          if [ -n "$latest_run" ]; then
+            latest_status="$(jq -r '.status' <<<"$latest_run")"
+            latest_conclusion="$(jq -r '.conclusion' <<<"$latest_run")"
+            latest_url="$(jq -r '.url' <<<"$latest_run")"
+
+            if [ "$latest_status" != "completed" ]; then
+              echo "add-version is already $latest_status for $picked ($latest_url). Skipping dispatch."
+              exit 0
+            fi
+
+            if [ "$latest_conclusion" != "success" ]; then
+              echo "The most recent add-version run for $picked $latest_conclusion ($latest_url)."
+              echo "Not re-dispatching; investigate or re-run that run first."
+              {
+                echo "**Skipped \`$picked\`:** the most recent [add-version run]($latest_url) $latest_conclusion and left no open tracking issue."
+                echo "Re-run add-version.yml once the cause is fixed — a successful run clears this guard."
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
           fi
 
           if [ "${DRY_RUN:-false}" = "true" ]; then


### PR DESCRIPTION
Two problems kept the scheduled job from releasing 3.9.0 for over a week. Both are fixed here. Rebased onto `main` after #340.

## 1. The dispatch guard got permanently stuck

The guard added in 7b29a6d blocked dispatch if **any** past `add-version` run for the picked version had failed:

```
gh run list --workflow=add-version.yml --status=failure --limit 50 ...
```

The 11 failures from the checkout-ordering bug that same commit fixed were still in the run list, so every scheduled run since Aug 26 picked `3.9.0-RC5`, hit the guard, and exited:

```
add-version already failed for 3.9.0-RC5 (.../runs/32977179971) without leaving an open issue.
Not re-dispatching; investigate that run first.
```

The guard had no way to notice the cause had been fixed — it was a permanent stop until those runs aged out of the last 50.

Now only the **latest** run for the version counts, so a successful or manual re-run clears the block on its own. An in-progress run is also treated as "skip", which subsumes the open-tracking-issue check for the window before the issue exists.

The title match is also anchored with `startswith("Add Scala Version <v> (")`. The old `contains("Version 3.9.0 ")` is a substring test, so `3.9.0` and `3.9.0-RC5` could match each other's runs.

## 2. Finals queue behind their own RCs

The picker takes the oldest candidate, so reaching a final release means publishing every RC before it first — three scheduled runs (~1.5 days) to get from RC5 to 3.9.0. Those RCs then get dropped from `scala-versions` again once the final ships, as in d4200da.

RCs whose final release is in the same candidate batch are now pruned. An RC with no final present is still picked up, so pre-release support is unaffected.

## Verification

Ran the extracted step against the live GitHub and Maven Central APIs.

Replaying the exact outage (`scala-versions` rolled back to before 3.9.0) — under the old code this picked RC5 and exited:

```
Using cutoff 2026-07-22T20:30:39Z (publish date of most recent known version 3.9.0-RC4)
Found 4 new release(s)
Skipping 2 RC(s) superseded by a final release in this batch.
  - 3.9.0 (created 2026-08-26T12:43:25Z)
  - 3.10.0-RC1 (created 2026-08-26T22:32:51Z)
3.9.0: available on Maven Central
[dry-run] Would dispatch add-version.yml for 3.9.0
```

Guard branches against real run history:

```
3.9.0-RC5   -> failure     => SKIP (blocked)
3.9.0       -> success     => DISPATCH (guard cleared)
3.10.0-RC1  -> success     => DISPATCH (guard cleared)
3.11.0      -> no prior run => DISPATCH
```

Against current `main`, correctly quiet: `Found 0 new release(s) -> Nothing to do.`

## Note

3.9.0 and 3.10.0-RC1 were both released manually while debugging this, so there is nothing pending for the scheduled job to pick up right now. This change is what stops it seizing up the next time an `add-version` run fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)